### PR TITLE
[fix/editor]: generate unique id for text addition

### DIFF
--- a/src/pages/editor/constants/payload.ts
+++ b/src/pages/editor/constants/payload.ts
@@ -1,8 +1,6 @@
-import { generateId } from "@designcombo/timeline";
 import { DEFAULT_FONT } from "./font";
 
 export const TEXT_ADD_PAYLOAD = {
-  id: generateId(),
   display: {
     from: 0,
     to: 5000,

--- a/src/pages/editor/menu-item/texts.tsx
+++ b/src/pages/editor/menu-item/texts.tsx
@@ -1,4 +1,5 @@
 import { Button, buttonVariants } from "@/components/ui/button";
+import { generateId } from "@designcombo/timeline";
 import { ADD_TEXT } from "@designcombo/state";
 import { dispatch } from "@designcombo/events";
 import { useIsDraggingOverTimeline } from "../hooks/is-dragging-over-timeline";
@@ -11,7 +12,10 @@ export const Texts = () => {
 
   const handleAddText = () => {
     dispatch(ADD_TEXT, {
-      payload: TEXT_ADD_PAYLOAD,
+      payload: {
+        ...TEXT_ADD_PAYLOAD,
+        id: generateId(),
+      },
       options: {},
     });
   };


### PR DESCRIPTION
## Summary
This PR addresses a bug in the text editor where adding text a second time would not display the new text, even though an empty text entry appeared in the timeline.

## Issue Description
- **Problem:** The text payload contained a static id, causing new text additions to replace the existing text.
- **Behavior:** On first addition, text is correctly added. On subsequent additions, the timeline shows an empty text (due to the static id) rather than adding a new text element.

## Changes Made
- Removed the `id` from the TEXT_ADD_PAYLOAD.
- Updated the `handleAddText` function to include `id: generateId()` so that every call produces a unique id.

## How to Test
1. Open the text editor.
2. Add text multiple times.
3. Verify that each text element is added with a unique id and is displayed correctly.

